### PR TITLE
[⚙️ Setting] 라우터 세팅 및 reset-styled-components 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
 				"react-redux": "^9.1.2",
 				"redux": "^5.0.1",
 				"sass": "^1.81.0",
-				"styled-components": "^6.1.13"
+				"styled-components": "^6.1.13",
+				"styled-reset": "^4.5.2"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.13.0",
@@ -5895,6 +5896,18 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"license": "0BSD"
+		},
+		"node_modules/styled-reset": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.5.2.tgz",
+			"integrity": "sha512-dbAaaVEhweBs2FGfqGBdW6oMcMK8238C2X5KCxBhUQJX92m/QyUfzRADOXhdXiXNkIPELtMCd72YY9eCdORfIw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"styled-components": ">=4.0.0 || >=5.0.0 || >=6.0.0"
+			}
 		},
 		"node_modules/stylis": {
 			"version": "4.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@reduxjs/toolkit": "^2.3.0",
+				"@tanstack/react-query": "^5.61.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-redux": "^9.1.2",
+				"react-router-dom": "^7.0.0",
 				"redux": "^5.0.1",
 				"sass": "^1.81.0",
 				"styled-components": "^6.1.13",
@@ -19,6 +21,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.13.0",
+				"@types/node": "^22.9.1",
 				"@types/react": "^18.3.12",
 				"@types/react-dom": "^18.3.1",
 				"@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -1554,6 +1557,32 @@
 				"win32"
 			]
 		},
+		"node_modules/@tanstack/query-core": {
+			"version": "5.60.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.60.6.tgz",
+			"integrity": "sha512-tI+k0KyCo1EBJ54vxK1kY24LWj673ujTydCZmzEZKAew4NqZzTaVQJEuaG1qKj2M03kUHN46rchLRd+TxVq/zQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/react-query": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.61.0.tgz",
+			"integrity": "sha512-SBzV27XAeCRBOQ8QcC94w2H1Md0+LI0gTWwc3qRJoaGuewKn5FNW4LSqwPFJZVEItfhMfGT7RpZuSFXjTi12pQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/query-core": "5.60.6"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19"
+			}
+		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1599,12 +1628,28 @@
 				"@babel/types": "^7.20.7"
 			}
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+			"integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.19.8"
+			}
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.13",
@@ -2428,6 +2473,15 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cookie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -5184,6 +5238,46 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-router": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.0.tgz",
+			"integrity": "sha512-1xf+yMVhUjAzZGY90ZnYJ9KVe1R8FggpugzRBkh+p6vl4cC1sHDe3nO+r5rxWTAgCMf8uN5hfoV2M7rLVTWPUA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/cookie": "^0.6.0",
+				"cookie": "^1.0.1",
+				"set-cookie-parser": "^2.6.0",
+				"turbo-stream": "2.4.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-router-dom": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.0.tgz",
+			"integrity": "sha512-2QAxXpwgQuh423C64oZiV2cCKPCNUgZxcvZaS8O0PAHPZ/z8kTq7YbGD4KTNZm6Yj66d+HAfGkWPp8MCpdtD+Q==",
+			"license": "MIT",
+			"dependencies": {
+				"react-router": "7.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
@@ -5492,6 +5586,12 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
+		},
+		"node_modules/set-cookie-parser": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+			"license": "MIT"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -5998,6 +6098,12 @@
 			"dev": true,
 			"license": "0BSD"
 		},
+		"node_modules/turbo-stream": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+			"integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+			"license": "ISC"
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6157,6 +6263,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
 	},
 	"dependencies": {
 		"@reduxjs/toolkit": "^2.3.0",
+		"@tanstack/react-query": "^5.61.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-redux": "^9.1.2",
+		"react-router-dom": "^7.0.0",
 		"redux": "^5.0.1",
 		"sass": "^1.81.0",
 		"styled-components": "^6.1.13",
@@ -32,6 +34,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.13.0",
+		"@types/node": "^22.9.1",
 		"@types/react": "^18.3.12",
 		"@types/react-dom": "^18.3.1",
 		"@typescript-eslint/eslint-plugin": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"react-redux": "^9.1.2",
 		"redux": "^5.0.1",
 		"sass": "^1.81.0",
-		"styled-components": "^6.1.13"
+		"styled-components": "^6.1.13",
+		"styled-reset": "^4.5.2"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.13.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,17 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
-import './App.css';
-import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
-
-const GlobalStyle = createGlobalStyle`
-	${reset}
-`;
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from 'react-router-dom';
+import GlobalStyles from '@/styles/GlobalStyles';
+import { router } from '@/routes/router';
 
 function App() {
-	const [count, setCount] = useState(0);
+	const queryClient = new QueryClient();
 
 	return (
 		<>
-			<GlobalStyle />
-			<div>
-				<a href="https://vite.dev" target="_blank" rel="noreferrer">
-					<img src={viteLogo} className="logo" alt="Vite logo" />
-				</a>
-				<a href="https://react.dev" target="_blank" rel="noreferrer">
-					<img src={reactLogo} className="logo react" alt="React logo" />
-				</a>
-			</div>
-			<h1>Vite + React</h1>
-			<div className="card">
-				<button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-				<p>
-					Edit <code>src/App.tsx</code> and save to test HMR
-				</p>
-			</div>
-			<p className="read-the-docs">Click on the Vite and React logos to learn more</p>
+			<GlobalStyles />
+			<QueryClientProvider client={queryClient}>
+				<RouterProvider router={router} />
+			</QueryClientProvider>
 		</>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,19 @@ import { useState } from 'react';
 import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
+import { createGlobalStyle } from 'styled-components';
+import reset from 'styled-reset';
+
+const GlobalStyle = createGlobalStyle`
+	${reset}
+`;
 
 function App() {
 	const [count, setCount] = useState(0);
 
 	return (
 		<>
+			<GlobalStyle />
 			<div>
 				<a href="https://vite.dev" target="_blank" rel="noreferrer">
 					<img src={viteLogo} className="logo" alt="Vite logo" />

--- a/src/pages/Calendar/Calendar.tsx
+++ b/src/pages/Calendar/Calendar.tsx
@@ -1,0 +1,5 @@
+function Calendar() {
+	return <h2>Calendar Page</h2>;
+}
+
+export default Calendar;

--- a/src/pages/CorrectionRequest/CorrectionRequest.tsx
+++ b/src/pages/CorrectionRequest/CorrectionRequest.tsx
@@ -1,0 +1,5 @@
+function CorrectionRequest() {
+	return <h2>Correction Request Page</h2>;
+}
+
+export default CorrectionRequest;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,0 +1,5 @@
+function Home() {
+	return <h2>Home Page</h2>;
+}
+
+export default Home;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,0 +1,5 @@
+function Login() {
+	return <h2>Login Page</h2>;
+}
+
+export default Login;

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,0 +1,5 @@
+function Profile() {
+	return <h2>Profile Page</h2>;
+}
+
+export default Profile;

--- a/src/pages/SalaryDetails/SalaryDetails.tsx
+++ b/src/pages/SalaryDetails/SalaryDetails.tsx
@@ -1,0 +1,5 @@
+function SalaryDetails() {
+	return <h2>Salary Details Page</h2>;
+}
+
+export default SalaryDetails;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,0 +1,16 @@
+import { createBrowserRouter } from 'react-router-dom';
+import Home from '@/pages/Home/Home';
+import Login from '@/pages/Login/Login';
+import Profile from '@/pages/Profile/Profile';
+import SalaryDetails from '@/pages/SalaryDetails/SalaryDetails';
+import CorrectionRequest from '@/pages/CorrectionRequest/CorrectionRequest';
+import Calendar from '@/pages/Calendar/Calendar';
+
+export const router = createBrowserRouter([
+	{ path: '/', element: <Home /> },
+	{ path: '/login', element: <Login /> },
+	{ path: '/profile', element: <Profile /> },
+	{ path: '/salary-details', element: <SalaryDetails /> },
+	{ path: '/correction-request', element: <CorrectionRequest /> },
+	{ path: '/calendar', element: <Calendar /> },
+]);

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -1,0 +1,17 @@
+import { createGlobalStyle } from 'styled-components';
+import reset from 'styled-reset';
+
+const GlobalStyle = createGlobalStyle`
+  ${reset}
+  /* 추가적인 글로벌 스타일을 여기에 작성할 수 있습니다. */
+  body {
+    font-family: 'Arial', sans-serif;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+`;
+
+export default function GlobalStyles() {
+	return <GlobalStyle />;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,15 @@
 {
 	"files": [],
-	"references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+	"references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"moduleResolution": "node",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"]
+		},
+		"types": ["node"]
+	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
 	plugins: [react()],
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, './src'),
+		},
+	},
 });


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[라우터 세팅 및 reset-styled-components 추가]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
- 라우터 세팅 추가
- reset-styled-components 추가

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.
- [ ] 라우터에 따라 기본 경로를 임의로 설정하여 추가하였습니다.
- [ ] 리셋 css와 글로벌 css styled-components를 적용가능하게 하였습니다.
- [ ] @tanstack/react-query, styled-reset을 추가하였습니다.
- [ ] vite.config와 tsconfig에 '@/'로 src 경로 path 지정할 수 있게 변경하였습니다.


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
