### PR TITLE
[✨ Feature] 일정추가 Modal Form 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,14 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Vite + React + TS</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<div id="modal"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
 </html>

--- a/src/components/modal/ModalPortal.tsx
+++ b/src/components/modal/ModalPortal.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+const ModalPortal = ({ children }: { children: ReactNode }) => {
+	const modalRoot = document.getElementById('modal') as HTMLElement;
+	return createPortal(children, modalRoot);
+};
+
+export default ModalPortal;

--- a/src/components/modal/ScheduleModal.tsx
+++ b/src/components/modal/ScheduleModal.tsx
@@ -2,7 +2,13 @@ import { formatToKoreanTime } from '@/utils/dateFormatter';
 import styled from 'styled-components';
 import { Toggle } from '../toggle/Toggle';
 
-const ScheduleModal = () => {
+//admin의 경우 회원가입 시 관리자인지 구분하여 저장하는 데이터베이스 데이터가 있기때문에 그걸 토대로
+//각 사용자에 맞는 UI를 보여주면 될것으로 보임.
+
+interface ScheduleModalProps {
+	state?: string;
+}
+const ScheduleModal = ({ state = 'admin' }: ScheduleModalProps) => {
 	const dateAt = formatToKoreanTime(new Date());
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -11,11 +17,21 @@ const ScheduleModal = () => {
 	return (
 		<ModalOverlay>
 			<ModalContent onSubmit={handleSubmit}>
-				<h1>일정 추가</h1>
+				<ModalContentTop>
+					<h1>일정 추가</h1>
+					<InputWrapper>
+						<Icon onClick={() => console.log('검색')}>🔍</Icon>
+						{state === 'admin' && (
+							<ModalSearchInput type="text" placeholder="이름을 검색하여 주세요." />
+						)}
+					</InputWrapper>
+				</ModalContentTop>
 				<ModalWrapperTopSubTitle>기간</ModalWrapperTopSubTitle>
-				<DateTimeInput type="datetime-local" defaultValue={dateAt} id="startAt" />
-				<span> - </span>
-				<DateTimeInput type="datetime-local" defaultValue={dateAt} id="endAt" />
+				<ModalWrapperContainerTop>
+					<DateTimeInput type="datetime-local" defaultValue={dateAt} id="startAt" />
+					<CloseTime type="text" defaultValue={'5'} />
+					<span>시간</span>
+				</ModalWrapperContainerTop>
 				<ModalToggleContainer>
 					<Toggle />
 					<span>반복 설정</span>
@@ -29,21 +45,6 @@ const ScheduleModal = () => {
 				</ModalToggleContainer>
 				<WorkWrapper>
 					<WorkTitle>업무</WorkTitle>
-					<WorkUl>
-						<WorkLITitle>시간</WorkLITitle>
-						<li>
-							<input type="checkbox" value={'오픈'} id="open" />
-							<label htmlFor="open">오픈</label>
-						</li>
-						<li>
-							<input type="checkbox" value={'미들'} id="middle" />
-							<label htmlFor="middle">미들</label>
-						</li>
-						<li>
-							<input type="checkbox" value={'마감'} id="close" />
-							<label htmlFor="close">마감</label>
-						</li>
-					</WorkUl>
 					<WorkUl>
 						<WorkTitle>종류</WorkTitle>
 						<li>
@@ -59,27 +60,7 @@ const ScheduleModal = () => {
 							<label htmlFor="close">플로어</label>
 						</li>
 					</WorkUl>
-					<TodoInput type="text" />
-					<StatusContainer>
-						<StatusWarpperTop>
-							<span>상태</span>
-							<select>
-								<option>시작전</option>
-								<option>진행중</option>
-								<option>완료</option>
-							</select>
-						</StatusWarpperTop>
-						<StatusWrapper>
-							<span>컬러</span>
-							<RoundList>
-								<RoundListItem />
-								<RoundListItem />
-								<RoundListItem />
-								<RoundListItem />
-								<RoundListItem />
-							</RoundList>
-						</StatusWrapper>
-					</StatusContainer>
+					<TodoInput type="text" placeholder={'업무에 대한 설명을 작성해주세요.'} />
 				</WorkWrapper>
 				<ButtonContainer>
 					<CreateButton type="submit">추가하기</CreateButton>
@@ -111,6 +92,32 @@ const ModalContent = styled.form`
 	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 `;
 
+const ModalContentTop = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+`;
+
+const ModalSearchInput = styled.input`
+	width: 327px;
+	height: 32px;
+	border-radius: 10px;
+
+	border-radius: 5px;
+	outline: none;
+	font-size: 14px;
+
+	&:focus {
+		border-color: #007bff;
+	}
+`;
+
+const ModalWrapperContainerTop = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+`;
+
 const ModalWrapperTopSubTitle = styled.h2`
 	margin-top: 1rem;
 	margin-bottom: 1rem;
@@ -132,7 +139,7 @@ const DateTimeInput = styled.input`
 	}
 	&::-webkit-calendar-picker-indicator {
 		//아이콘 custom
-		/* background-image: url('your-icon-url.png'); */
+		background-image: none;
 		background-size: contain;
 		background-repeat: no-repeat;
 		width: 20px;
@@ -178,16 +185,10 @@ const WorkUl = styled.ul`
 	gap: 1rem;
 `;
 
-const WorkLITitle = styled.li`
-	font-weight: bold;
-	color: #000;
-`;
-
-const StatusWarpperTop = styled.div`
-	display: flex;
-	gap: 1rem;
-	margin-top: 0.2rem;
-	align-items: center;
+const CloseTime = styled.input`
+	width: 24px;
+	text-align: center;
+	/* margin-top: 1rem; */
 `;
 
 const TodoInput = styled.input`
@@ -196,22 +197,6 @@ const TodoInput = styled.input`
 	border: 1px solid black;
 	height: 30px;
 	padding-left: 10px;
-`;
-
-const StatusContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-`;
-const StatusWrapper = styled.div`
-	display: flex;
-	gap: 0.2rem;
-`;
-
-const RoundList = styled.ul`
-	display: flex;
-	gap: 1rem;
-	margin-left: 0.8rem;
 `;
 
 const ButtonContainer = styled.div`
@@ -224,11 +209,18 @@ const CreateButton = styled.button`
 	background-color: transparent;
 	color: var(--color-skyblue-light-dark);
 	cursor: pointer;
+	margin-top: 20px;
 `;
 
-const RoundListItem = styled.li`
-	width: 15px; // 원의 가로 크기
-	height: 15px; // 원의 세로 크기
-	background-color: #3498db; // 배경 색
-	border-radius: 50%;
+const Icon = styled.span`
+	position: absolute;
+	top: 50%;
+	right: 25%;
+	transform: translateY(-50%);
+	font-size: 16px;
+`;
+
+const InputWrapper = styled.div`
+	position: relative;
+	display: inline-block;
 `;

--- a/src/components/modal/ScheduleModal.tsx
+++ b/src/components/modal/ScheduleModal.tsx
@@ -1,0 +1,234 @@
+import { formatToKoreanTime } from '@/utils/dateFormatter';
+import styled from 'styled-components';
+import { Toggle } from '../toggle/Toggle';
+
+const ScheduleModal = () => {
+	const dateAt = formatToKoreanTime(new Date());
+	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		console.log('submit');
+	};
+	return (
+		<ModalOverlay>
+			<ModalContent onSubmit={handleSubmit}>
+				<h1>일정 추가</h1>
+				<ModalWrapperTopSubTitle>기간</ModalWrapperTopSubTitle>
+				<DateTimeInput type="datetime-local" defaultValue={dateAt} id="startAt" />
+				<span> - </span>
+				<DateTimeInput type="datetime-local" defaultValue={dateAt} id="endAt" />
+				<ModalToggleContainer>
+					<Toggle />
+					<span>반복 설정</span>
+					<select>
+						<option>반복주기</option>
+						<option>년</option>
+						<option>월</option>
+						<option>일</option>
+					</select>
+					<DateInput type="date" defaultValue={dateAt} />
+				</ModalToggleContainer>
+				<WorkWrapper>
+					<WorkTitle>업무</WorkTitle>
+					<WorkUl>
+						<WorkLITitle>시간</WorkLITitle>
+						<li>
+							<input type="checkbox" value={'오픈'} id="open" />
+							<label htmlFor="open">오픈</label>
+						</li>
+						<li>
+							<input type="checkbox" value={'미들'} id="middle" />
+							<label htmlFor="middle">미들</label>
+						</li>
+						<li>
+							<input type="checkbox" value={'마감'} id="close" />
+							<label htmlFor="close">마감</label>
+						</li>
+					</WorkUl>
+					<WorkUl>
+						<WorkTitle>종류</WorkTitle>
+						<li>
+							<input type="checkbox" value={'오픈'} id="open" />
+							<label htmlFor="open">매표</label>
+						</li>
+						<li>
+							<input type="checkbox" value={'미들'} id="middle" />
+							<label htmlFor="middle">매점</label>
+						</li>
+						<li>
+							<input type="checkbox" value={'마감'} id="close" />
+							<label htmlFor="close">플로어</label>
+						</li>
+					</WorkUl>
+					<TodoInput type="text" />
+					<StatusContainer>
+						<StatusWarpperTop>
+							<span>상태</span>
+							<select>
+								<option>시작전</option>
+								<option>진행중</option>
+								<option>완료</option>
+							</select>
+						</StatusWarpperTop>
+						<StatusWrapper>
+							<span>컬러</span>
+							<RoundList>
+								<RoundListItem />
+								<RoundListItem />
+								<RoundListItem />
+								<RoundListItem />
+								<RoundListItem />
+							</RoundList>
+						</StatusWrapper>
+					</StatusContainer>
+				</WorkWrapper>
+				<ButtonContainer>
+					<CreateButton type="submit">추가하기</CreateButton>
+				</ButtonContainer>
+			</ModalContent>
+		</ModalOverlay>
+	);
+};
+
+export default ScheduleModal;
+
+const ModalOverlay = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.5);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+const ModalContent = styled.form`
+	background: white;
+	padding: 20px;
+	border-radius: 8px;
+	min-width: 300px;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+`;
+
+const ModalWrapperTopSubTitle = styled.h2`
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+`;
+
+const ModalToggleContainer = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 2rem;
+	margin-top: 1rem;
+`;
+
+const DateTimeInput = styled.input`
+	border: none;
+	font-size: 20px;
+	&:focus {
+		border: none;
+		outline: none;
+	}
+	&::-webkit-calendar-picker-indicator {
+		//아이콘 custom
+		/* background-image: url('your-icon-url.png'); */
+		background-size: contain;
+		background-repeat: no-repeat;
+		width: 20px;
+		height: 20px;
+		cursor: pointer;
+	}
+`;
+
+const DateInput = styled.input`
+	border: none;
+	font-size: 14px;
+	&:focus {
+		border: none;
+		outline: none;
+	}
+	&::-webkit-calendar-picker-indicator {
+		//아이콘 custom
+		background-image: none;
+		background-size: contain;
+		background-repeat: no-repeat;
+		width: 20px;
+		height: 20px;
+		cursor: pointer;
+	}
+`;
+
+const WorkWrapper = styled.div`
+	margin-top: 1rem;
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
+	gap: 0.5rem;
+`;
+
+const WorkTitle = styled.h2`
+	font-weight: bold;
+	color: #000;
+`;
+
+const WorkUl = styled.ul`
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+`;
+
+const WorkLITitle = styled.li`
+	font-weight: bold;
+	color: #000;
+`;
+
+const StatusWarpperTop = styled.div`
+	display: flex;
+	gap: 1rem;
+	margin-top: 0.2rem;
+	align-items: center;
+`;
+
+const TodoInput = styled.input`
+	width: 400px;
+	border-radius: 10px;
+	border: 1px solid black;
+	height: 30px;
+	padding-left: 10px;
+`;
+
+const StatusContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+`;
+const StatusWrapper = styled.div`
+	display: flex;
+	gap: 0.2rem;
+`;
+
+const RoundList = styled.ul`
+	display: flex;
+	gap: 1rem;
+	margin-left: 0.8rem;
+`;
+
+const ButtonContainer = styled.div`
+	float: right;
+`;
+
+const CreateButton = styled.button`
+	border: var(--color-skyblue-light-dark);
+	outline: var(--color-skyblue-light-dark);
+	background-color: transparent;
+	color: var(--color-skyblue-light-dark);
+	cursor: pointer;
+`;
+
+const RoundListItem = styled.li`
+	width: 15px; // 원의 가로 크기
+	height: 15px; // 원의 세로 크기
+	background-color: #3498db; // 배경 색
+	border-radius: 50%;
+`;

--- a/src/components/modal/ScheduleModal.tsx
+++ b/src/components/modal/ScheduleModal.tsx
@@ -22,14 +22,19 @@ const ScheduleModal = ({ state = 'admin' }: ScheduleModalProps) => {
 					<InputWrapper>
 						<Icon onClick={() => console.log('검색')}>🔍</Icon>
 						{state === 'admin' && (
-							<ModalSearchInput type="text" placeholder="이름을 검색하여 주세요." />
+							<ModalSearchInput
+								type="text"
+								placeholder="이름을 검색하여 주세요."
+								required={true}
+								maxLength={5}
+							/>
 						)}
 					</InputWrapper>
 				</ModalContentTop>
 				<ModalWrapperTopSubTitle>기간</ModalWrapperTopSubTitle>
 				<ModalWrapperContainerTop>
 					<DateTimeInput type="datetime-local" defaultValue={dateAt} id="startAt" />
-					<CloseTime type="text" defaultValue={'5'} />
+					<CloseTime type="text" defaultValue={'5'} required={true} maxLength={2} />
 					<span>시간</span>
 				</ModalWrapperContainerTop>
 				<ModalToggleContainer>
@@ -60,7 +65,7 @@ const ScheduleModal = ({ state = 'admin' }: ScheduleModalProps) => {
 							<label htmlFor="close">플로어</label>
 						</li>
 					</WorkUl>
-					<TodoInput type="text" placeholder={'업무에 대한 설명을 작성해주세요.'} />
+					<TodoInput type="text" placeholder={'업무에 대한 설명을 작성해주세요.'} maxLength={30} />
 				</WorkWrapper>
 				<ButtonContainer>
 					<CreateButton type="submit">추가하기</CreateButton>

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -34,17 +34,17 @@ const ToggleContainer = styled.div`
 `;
 
 export const Toggle = () => {
-	const [isOn, setisOn] = useState(false);
+	const [isActive, setIsActive] = useState(false);
 
 	const toggleHandler = () => {
-		setisOn(!isOn);
+		setIsActive(!isActive);
 	};
 
 	return (
 		<>
 			<ToggleContainer onClick={toggleHandler}>
-				<div className={`toggle-container ${isOn ? 'toggle--checked' : null}`} />
-				<div className={`toggle-circle ${isOn ? 'toggle--checked' : null}`} />
+				<div className={`toggle-container ${isActive ? 'toggle--checked' : null}`} />
+				<div className={`toggle-circle ${isActive ? 'toggle--checked' : null}`} />
 			</ToggleContainer>
 		</>
 	);

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const ToggleContainer = styled.div`
+	position: relative;
+	cursor: pointer;
+
+	> .toggle-container {
+		width: 50px;
+		height: 24px;
+		border-radius: 30px;
+		background-color: rgb(233, 233, 234);
+	}
+	> .toggle--checked {
+		background-color: var(--color-black);
+		transition: 0.5s;
+	}
+
+	> .toggle-circle {
+		position: absolute;
+		top: 1px;
+		left: 1px;
+		width: 22px;
+		height: 22px;
+		border-radius: 50%;
+		background-color: rgb(255, 254, 255);
+		transition: 0.5s;
+		//.toggle--checked 클래스가 활성화 되었을 경우의 CSS를 구현
+	}
+	> .toggle--checked {
+		left: 27px;
+		transition: 0.5s;
+	}
+`;
+
+export const Toggle = () => {
+	const [isOn, setisOn] = useState(false);
+
+	const toggleHandler = () => {
+		setisOn(!isOn);
+	};
+
+	return (
+		<>
+			<ToggleContainer onClick={toggleHandler}>
+				<div className={`toggle-container ${isOn ? 'toggle--checked' : null}`} />
+				<div className={`toggle-circle ${isOn ? 'toggle--checked' : null}`} />
+			</ToggleContainer>
+		</>
+	);
+};

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -33,6 +33,9 @@ export function Home() {
 			</Button>
 			{status.isError && <Error>오류 발생</Error>}
 			{status.isLoading && <Loading size={40} />}
+			{/* <ModalPortal>
+				<ScheduleModal />
+			</ModalPortal> */}
 			{/* 홈 페이지 내용 */}
 		</S.HomeContainer>
 	);

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -3,8 +3,11 @@ import { db } from '@/firebaseConfig';
 import { doc, setDoc } from 'firebase/firestore';
 import * as S from './Home.styles';
 import { Button, Error, Loading } from '@/components';
+import ModalPortal from '@/components/modal/ModalPortal';
+import ScheduleModal from '@/components/modal/ScheduleModal';
 
 export function Home() {
+	const [isOpen, setIsOpen] = useState<boolean>(false);
 	useEffect(() => {
 		const testFirebaseConnection = async () => {
 			try {
@@ -33,9 +36,13 @@ export function Home() {
 			</Button>
 			{status.isError && <Error>오류 발생</Error>}
 			{status.isLoading && <Loading size={40} />}
-			{/* <ModalPortal>
-				<ScheduleModal />
-			</ModalPortal> */}
+			<button onClick={() => setIsOpen(!isOpen)}>open</button>
+			{isOpen && (
+				<ModalPortal>
+					<ScheduleModal />
+				</ModalPortal>
+			)}
+
 			{/* 홈 페이지 내용 */}
 		</S.HomeContainer>
 	);

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,0 +1,9 @@
+export const formatToKoreanTime = (date: Date) => {
+	const koreaTime = new Date(date.toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+	const year = koreaTime.getFullYear();
+	const month = String(koreaTime.getMonth() + 1).padStart(2, '0');
+	const day = String(koreaTime.getDate()).padStart(2, '0');
+	const hour = String(koreaTime.getHours()).padStart(2, '0');
+	const minute = String(koreaTime.getMinutes()).padStart(2, '0');
+	return `${year}-${month}-${day} ${hour}:${minute}`;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

일정 관리 캘린더에서 일정을 추가할 수 있는 Modal Form 구현

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
- 일정 관리 캘린더에서 일정을 추가할 수 있는 Modal Form 구현
- React.portal을 사용하여 Modal 제작
- 일정반복을 주기를 위한 Toogle Component 생성
- 현재 날짜를 기준으로 하는 년월일시분 utils 폴더에 변환 함수 생성

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.
- [ ] 일정 관리 캘린더에서 일정을 추가할 수 있는 Modal Form 구현
- [ ] React.portal을 사용하여 Modal 제작
- [ ] 일정반복을 주기를 위한 Toogle Component 생성
- [ ] 현재 날짜를 기준으로 하는 년 월 일 시 분 utils 폴더에 변환 함수 생성



## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/79e27e99-cc20-48b4-a0f7-285a0b4919e9)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
