### PR TITLE
[🔧 Fix] schedule modal form 수정, crud 테스트

### DIFF
--- a/src/components/schedule-management/calendar/user-calender/UserCalendar.tsx
+++ b/src/components/schedule-management/calendar/user-calender/UserCalendar.tsx
@@ -16,11 +16,11 @@ export const UserCalendarComponent = ({ isManagementPage }: CalendarComponentPro
 	const selectedDate = useAppSelector((state) => state.schedule.selectedDate);
 	const user = useAppSelector((state) => state.user.user);
 	const userId = user?.id;
-	const modalState = useAppSelector((state) => state.modal);
+	// const modalState = useAppSelector((state) => state.modal);
 
-	useEffect(() => {
-		console.log('전체 모달 상태:', modalState);
-	}, [modalState]);
+	// useEffect(() => {
+	// 	console.log('전체 모달 상태:', modalState);
+	// }, [modalState]);
 
 	useEffect(() => {
 		console.log('isManagementPage:', isManagementPage);

--- a/src/components/schedule-management/schedule-card/admin-schedule-card/AdminScheduleCard.tsx
+++ b/src/components/schedule-management/schedule-card/admin-schedule-card/AdminScheduleCard.tsx
@@ -5,7 +5,7 @@ import {
 	TScheduleShiftType,
 } from '@/types/schedule';
 import * as S from './AdminScheduleCard.styles';
-import { formatToKoreanTime, toDate } from '@/utils/dateFormatter';
+import { formatTime } from '@/utils/dateFormatter';
 
 interface AdminScheduleCardProps {
 	schedulesItem: {
@@ -53,7 +53,7 @@ const AdminScheduleCard = ({ schedulesItem }: AdminScheduleCardProps) => {
 				<span>{categoryConvert(schedulesItem.category)}</span>
 			</div>
 			<S.ScheduleCardTime>
-				<span>{formatToKoreanTime(toDate(schedulesItem.end_date_time))}</span>
+				<span>{formatTime(new Date(schedulesItem.end_date_time))}</span>
 			</S.ScheduleCardTime>
 			<div>
 				<span>{schedulesItem.description}</span>

--- a/src/components/schedule-management/schedule-modal/ScheduleModal.tsx
+++ b/src/components/schedule-management/schedule-modal/ScheduleModal.tsx
@@ -77,15 +77,15 @@ const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 			: null;
 
 	// 디버깅용
-	console.log({
-		errors: errors,
-		noneStartDateTimeError: noneStartDateTimeError,
-		noneEndDateError: noneEndDateError,
-		repeatEndDateError: repeatEndDateError,
-		isSubmitting: isSubmitting,
-		data: watch(),
-		currentUser: user,
-	});
+	// console.log({
+	// 	errors: errors,
+	// 	noneStartDateTimeError: noneStartDateTimeError,
+	// 	noneEndDateError: noneEndDateError,
+	// 	repeatEndDateError: repeatEndDateError,
+	// 	isSubmitting: isSubmitting,
+	// 	data: watch(),
+	// 	currentUser: user,
+	// });
 
 	// 날짜 선택시 분을 00으로 초기화
 	const handleDateTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -150,8 +150,9 @@ const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 				await handleAddSchedule(newSchedules);
 				dispatch(setIsScheduleAddModalOpen(false)); // 일정 추가 모달 닫기
 			} else {
-				// edit 모드이고 반복 일정인 경우
+				// edit 모드
 				if (selectedSchedule) {
+					// 반복 일정인 경우
 					const repeatedSchedules = filteredRepeatSchedules(selectedSchedule, schedules);
 					const isRecurring = repeatedSchedules.length > 1;
 
@@ -160,10 +161,11 @@ const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 						dispatch(setIsConfirmModalOpen(true));
 						return; // 모달 응답 기다림
 					}
+
+					// 반복이 아닌 일정은 바로 수정
+					await handleEditSchedule(selectedSchedule, scheduleData, false);
+					dispatch(setIsScheduleEditModalOpen(false)); // 일정 수정 모달 닫기
 				}
-				// 반복이 아닌 일정은 바로 수정
-				await handleEditSchedule(scheduleData, false);
-				dispatch(setIsScheduleEditModalOpen(false)); // 일정 수정 모달 닫기
 			}
 		} catch (error) {
 			console.error('폼 제출 실패:', error);
@@ -174,9 +176,11 @@ const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 	const handleConfirmEdit = async (editAll: boolean) => {
 		try {
 			if (!pendingScheduleData) return;
-			await handleEditSchedule(pendingScheduleData, editAll);
-			dispatch(setIsConfirmModalOpen(false));
-			dispatch(setIsScheduleEditModalOpen(false));
+			if (selectedSchedule) {
+				await handleEditSchedule(selectedSchedule, pendingScheduleData, editAll);
+				dispatch(setIsConfirmModalOpen(false));
+				dispatch(setIsScheduleEditModalOpen(false));
+			}
 		} catch (error) {
 			console.error('스케줄 수정 실패:', error);
 		}

--- a/src/components/schedule-management/schedule-modal/ScheduleModal.tsx
+++ b/src/components/schedule-management/schedule-modal/ScheduleModal.tsx
@@ -21,6 +21,7 @@ import calculateScheduleShiftType from '@/utils/calculateScheduleShiftType';
 import calculateEndDateTime from '@/utils/calculateEndDateTime';
 import generateRepeatingSchedules from '@/utils/generateRepeatingSchedules';
 import filteredRepeatSchedules from '@/utils/filteredRepeatSchedules';
+import { formatDateTime, formatDate } from '@/utils/dateFormatter';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { v4 as uuidv4 } from 'uuid';
 import { useForm } from 'react-hook-form';
@@ -61,24 +62,30 @@ const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 		mode: 'onChange',
 	});
 
-	// 디버깅용
-	console.log({
-		errors: errors,
-		isSubmitting: isSubmitting,
-		data: watch(),
-		currentUser: user,
-	});
-
 	const startDateTime = watch('start_date_time'); // 시작 일시 값 감시
 	const repeatEndDate = watch('repeat_end_date'); // 종료일 값 감시
 
 	// 실시간으로 에러 메시지 생성
 	const noneStartDateTimeError = !startDateTime ? '시작일시를 선택해주세요' : null;
-	const noneEndDateError = !repeatEndDate ? '종료일을 선택해주세요' : null;
+	const noneEndDateError = isRepeatActive && !repeatEndDate ? '종료일을 선택해주세요' : null;
 	const repeatEndDateError =
-		repeatEndDate && startDateTime && new Date(repeatEndDate) < new Date(startDateTime)
+		isRepeatActive &&
+		repeatEndDate &&
+		startDateTime &&
+		new Date(repeatEndDate) < new Date(startDateTime)
 			? '반복 종료일은 시작일 이후여야 합니다'
 			: null;
+
+	// 디버깅용
+	console.log({
+		errors: errors,
+		noneStartDateTimeError: noneStartDateTimeError,
+		noneEndDateError: noneEndDateError,
+		repeatEndDateError: repeatEndDateError,
+		isSubmitting: isSubmitting,
+		data: watch(),
+		currentUser: user,
+	});
 
 	// 날짜 선택시 분을 00으로 초기화
 	const handleDateTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -96,20 +103,14 @@ const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 		if (mode === 'edit' && selectedSchedule) {
 			setValue('category', selectedSchedule.category);
 			// datetime-local input을 위한 날짜 포맷팅
-			const formattedStartDate = new Date(selectedSchedule.start_date_time)
-				.toISOString()
-				.slice(0, 16);
-			setValue('start_date_time', formattedStartDate);
+			setValue('start_date_time', formatDateTime(new Date(selectedSchedule.start_date_time)));
 			setValue('time', selectedSchedule.time);
 			setValue('description', selectedSchedule.description || '');
 			if (selectedSchedule.repeat && selectedSchedule.repeat_end_date) {
 				setIsRepeatActive(true);
 				// date input을 위한 날짜 포맷팅
-				const formattedEndDate = new Date(selectedSchedule.repeat_end_date)
-					.toISOString()
-					.slice(0, 10);
 				setValue('repeat', selectedSchedule.repeat);
-				setValue('repeat_end_date', formattedEndDate);
+				setValue('repeat_end_date', formatDate(new Date(selectedSchedule.repeat_end_date)));
 			}
 		}
 	}, [mode, selectedSchedule, setValue]);

--- a/src/hooks/useScheduleManage.ts
+++ b/src/hooks/useScheduleManage.ts
@@ -50,15 +50,20 @@ export default function useScheduleManage(userId: string | null, schedules: TSch
 
 				if (!addResult.success) throw new Error('전체 수정 중 추가 실패');
 			} else {
-				const deleteResult = await dispatch(
-					removeScheduleFromSupabase(userId, [schedule.schedule_id]),
-				);
-
-				if (!deleteResult.success) throw new Error('단일 수정 전 삭제 실패');
-
-				// 단일 스케줄 수정시에도 repeat, repeat_end_date (반복 설정) 있으면 반복 배열 추가
+				// 단일 스케줄 수정
+				// repeat, repeat_end_date (반복 설정) 있으면 반복 배열 추가
 				const hasRepeat = schedule.repeat && schedule.repeat_end_date;
 				if (hasRepeat) {
+					// 반복 설정 있으면 일단 전체 스케줄 삭제
+					const schedulesToDelete = filteredRepeatSchedules(schedule, schedules);
+					const scheduleIdsToDelete = schedulesToDelete.map((s) => s.schedule_id);
+
+					const deleteResult = await dispatch(
+						removeScheduleFromSupabase(userId, scheduleIdsToDelete),
+					);
+
+					if (!deleteResult.success) throw new Error('단일 수정 전 삭제 실패');
+
 					// 반복 배열 생성, 추가
 					const updatedSchedules = generateRepeatingSchedules({
 						...schedule,

--- a/src/hooks/useScheduleManage.ts
+++ b/src/hooks/useScheduleManage.ts
@@ -24,25 +24,44 @@ export default function useScheduleManage(userId: string | null, schedules: TSch
 		}
 	};
 
-	const handleEditSchedule = async (schedule: TSchedule, editAll: boolean) => {
+	const handleEditSchedule = async (
+		prevSchedule: TSchedule,
+		newSchedule: TSchedule,
+		editAll: boolean,
+	) => {
 		if (!userId) throw new Error('userId가 없음');
+		if (!prevSchedule) throw new Error('이전 스케줄 정보 없음');
+
+		const isRepeatChanged = prevSchedule.repeat !== newSchedule.repeat;
+		const isRepeatEndDateChanged =
+			prevSchedule.repeat_end_date &&
+			newSchedule.repeat_end_date &&
+			new Date(prevSchedule.repeat_end_date).getTime() !==
+				new Date(newSchedule.repeat_end_date).getTime();
 
 		try {
-			if (editAll) {
-				// 전체 삭제 선택시 반복 스케줄들 모두 삭제 후 수정
-				// 기존 스케줄 삭제부터 함
-				const schedulesToDelete = filteredRepeatSchedules(schedule, schedules);
-				const scheduleIdsToDelete = schedulesToDelete.map((s) => s.schedule_id);
-
-				// Supabase 삭제
-				const deleteResult = await dispatch(
-					removeScheduleFromSupabase(userId, scheduleIdsToDelete),
+			if (editAll || isRepeatChanged || isRepeatEndDateChanged) {
+				// - 전체 수정
+				// - 또는 단일 수정시 repeat, repeat_end_date이 수정됐으면
+				// 기존 반복 스케줄 전체 삭제
+				const scheduleIds = filteredRepeatSchedules(prevSchedule, schedules).map(
+					(s) => s.schedule_id,
 				);
 
-				if (!deleteResult.success) throw new Error('전체 수정 전 삭제 실패');
+				console.log('수정 전 삭제할 스케줄:', {
+					editAll,
+					isRepeatChanged,
+					isRepeatEndDateChanged,
+					scheduleIds,
+				});
+
+				// Supabase 삭제, 추가
+				const deleteResult = await dispatch(removeScheduleFromSupabase(userId, scheduleIds));
+
+				if (!deleteResult.success) throw new Error('수정 전 삭제 실패');
 
 				const updatedSchedules = generateRepeatingSchedules({
-					...schedule,
+					...newSchedule,
 					schedule_id: uuidv4(), // 첫번째 스케줄에 새로운 ID 생성해줌
 				});
 
@@ -51,35 +70,12 @@ export default function useScheduleManage(userId: string | null, schedules: TSch
 				if (!addResult.success) throw new Error('전체 수정 중 추가 실패');
 			} else {
 				// 단일 스케줄 수정
-				// repeat, repeat_end_date (반복 설정) 있으면 반복 배열 추가
-				const hasRepeat = schedule.repeat && schedule.repeat_end_date;
-				if (hasRepeat) {
-					// 반복 설정 있으면 일단 전체 스케줄 삭제
-					const schedulesToDelete = filteredRepeatSchedules(schedule, schedules);
-					const scheduleIdsToDelete = schedulesToDelete.map((s) => s.schedule_id);
-
-					const deleteResult = await dispatch(
-						removeScheduleFromSupabase(userId, scheduleIdsToDelete),
-					);
-
-					if (!deleteResult.success) throw new Error('단일 수정 전 삭제 실패');
-
-					// 반복 배열 생성, 추가
-					const updatedSchedules = generateRepeatingSchedules({
-						...schedule,
-						schedule_id: uuidv4(), // 첫번째 스케줄에 새로운 ID 생성
-					});
-
-					const addResult = await dispatch(addScheduleToSupabase(userId, updatedSchedules));
-					if (!addResult.success) throw new Error('단일 스케줄 수정이 반복 스케줄로 수정 실패');
-				} else {
-					const editResult = await dispatch(editScheduleToSupabase([schedule]));
-
-					if (!editResult.success) throw new Error('단일 스케줄 수정 실패');
-				}
+				const editResult = await dispatch(editScheduleToSupabase([newSchedule]));
+				if (!editResult.success) throw new Error('단일 스케줄 수정 실패');
 			}
 		} catch (error) {
 			console.error('스케줄 수정 실패', error);
+			throw error;
 		}
 	};
 

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -3,11 +3,6 @@ export type TScheduleCategory = 'ticket' | 'snack' | 'floor';
 export type TScheduleShiftType = 'open' | 'middle' | 'close';
 export type TScheduleRepeatCycle = 'everyDay' | 'everyWeek' | 'everyMonth';
 
-// ❌ 일단 유지 - supabase로 마이그레이션 완료 후 삭제
-// import { Timestamp } from 'firebase/firestore';
-// export type TDate = Date | Timestamp;
-//
-
 export type TDate = Date | string; // supabase에 ISOstring으로 저장됨
 
 export interface TSchedule {

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,20 +1,3 @@
-// ❌ 일단 유지 - supabase로 마이그레이션 완료 후 삭제
-import { Timestamp } from 'firebase/firestore';
-export function toDate(input: Timestamp | Date): Date {
-	return input instanceof Timestamp ? input.toDate() : input;
-}
-// KST 기준으로 포맷된 문자열로 변환
-export const formatToKoreanTime = (date: Date) => {
-	const koreaTime = new Date(date.toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
-	const year = koreaTime.getFullYear();
-	const month = String(koreaTime.getMonth() + 1).padStart(2, '0');
-	const day = String(koreaTime.getDate()).padStart(2, '0');
-	const hour = String(koreaTime.getHours()).padStart(2, '0');
-	const minute = String(koreaTime.getMinutes()).padStart(2, '0');
-	return `${year}-${month}-${day} ${hour}:${minute}`;
-};
-//
-
 /**
  *  DB에는 UTC로 저장
  * 화면에는 KST로 표시

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -20,14 +20,17 @@ export const formatToKoreanTime = (date: Date) => {
  * 화면에는 KST로 표시
  * 날짜 비교도 KST 기준으로 수행
  */
-// UTC -> KST 변환 (날짜)
+
+// UTC -> KST 변환 (yyyy-MM-ddTHH:mm 형식)
+export const formatDateTime = (utcDate: Date) => {
+	const kstDate = new Date(utcDate.getTime() + 9 * 60 * 60 * 1000);
+	return kstDate.toISOString().slice(0, 16);
+};
+
+// UTC -> KST 변환 (yyyy-MM-dd 형식)
 export const formatDate = (utcDate: Date) => {
-	return new Intl.DateTimeFormat('ko-KR', {
-		timeZone: 'Asia/Seoul',
-		year: 'numeric',
-		month: 'numeric',
-		day: 'numeric',
-	}).format(utcDate);
+	const kstDate = new Date(utcDate.getTime() + 9 * 60 * 60 * 1000);
+	return kstDate.toISOString().slice(0, 10);
 };
 
 // UTC -> KST 변환 (시간)

--- a/src/utils/filteredRepeatSchedules.ts
+++ b/src/utils/filteredRepeatSchedules.ts
@@ -1,7 +1,7 @@
 import { TSchedule } from '@/types/schedule';
 
 export default function filteredRepeatSchedules(schedule: TSchedule, schedules: TSchedule[]) {
-	// console.log('스케줄 비교 시작:', { schedule, schedules });
+	console.log('스케줄 비교 시작:', { schedule, schedules });
 	return schedules.filter((s) => {
 		const match =
 			s.category === schedule.category &&
@@ -10,7 +10,7 @@ export default function filteredRepeatSchedules(schedule: TSchedule, schedules: 
 			s.schedule_shift_type === schedule.schedule_shift_type &&
 			s.description === schedule.description;
 
-		// console.log('비교 결과:', { schedule: s, match });
+		console.log('비교 결과:', { schedule: s, match });
 		return match;
 	});
 }

--- a/src/utils/filteredRepeatSchedules.ts
+++ b/src/utils/filteredRepeatSchedules.ts
@@ -1,7 +1,7 @@
 import { TSchedule } from '@/types/schedule';
 
 export default function filteredRepeatSchedules(schedule: TSchedule, schedules: TSchedule[]) {
-	console.log('스케줄 비교 시작:', { schedule, schedules });
+	// console.log('스케줄 비교 시작:', { schedule, schedules });
 	return schedules.filter((s) => {
 		const match =
 			s.category === schedule.category &&
@@ -10,7 +10,7 @@ export default function filteredRepeatSchedules(schedule: TSchedule, schedules: 
 			s.schedule_shift_type === schedule.schedule_shift_type &&
 			s.description === schedule.description;
 
-		console.log('비교 결과:', { schedule: s, match });
+		// console.log('비교 결과:', { schedule: s, match });
 		return match;
 	});
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

schedule modal form 수정
사용자 일정 crud 테스트
admin calender 날짜 타입 불일치 해결

## 📋 작업 내용

기존 수정 로직은 전체 수정 선택시나, 단일 스케줄 수정이라도 반복 설정이 있으면 전체 스케줄을 삭제하고 수정했습니다. 
그런데 이렇게 하면 반복 설정을 바꾸지 않고 다른 필드만 바꿔도 전체 스케줄이 삭제되고 다시 생겼습니다.

`handleEditSchedule`에서 수정 전 폼 데이터를 담은 매개변수 prevSchedule를 받아 editAll이 true일때나, repeat, repeat_end_date 값이 바뀌었을때만 전체 반복 스케줄을 삭제하고 새 스케줄을 생성해 추가하며
이 외 단일 스케줄 수정은 editScheduleToSupabase를 사용하도록 바꿨습니다.

<br/>

npm run build 후 
AdminScheduleCard.tsx 에서 타입 에러가 발생했습니다.
firebase에서 쓰던 날짜 타입 변환 함수를 사용해 에러가 발생했습니다.
`<span>{formatTime(new Date(schedulesItem.end_date_time))}</span>`
UTC -> KST로 시간을 변환하는 formatTime 함수를 사용해 해결했습니다.

## 🔧 변경 사항

작업 내용 참고해주세요.
그리고 스케줄 작업에 필요한 함수는 utils 참고 후 생성해주세요.

## 📸 스크린샷 (선택 사항)


## 📄 기타

close #85
