### PR TITLE
[✨ Feature] 메인페이지 급여명세서 관리자 버전

### DIFF
--- a/src/components/home/MainLayout.styles.ts
+++ b/src/components/home/MainLayout.styles.ts
@@ -155,3 +155,25 @@ export const PayrollTitle = styled.h3`
 	font-size: var(--font-medium);
 	font-weight: bold;
 `;
+
+export const SalaryManageList = styled.div`
+	padding: var(--space-large) var(--space-medium);
+`;
+
+export const SalaryManageContent = styled.div`
+	border-radius: var(--large-border-radius);
+	font-weight: 700;
+	padding: var(--space-medium);
+	display: flex;
+	justify-content: space-evenly;
+	margin-top: var(--space-medium);
+	border: 3px solid var(--color-blue);
+
+	&:first-child {
+		margin-top: 0;
+	}
+
+	&:hover {
+		cursor: pointer;
+	}
+`;

--- a/src/components/home/MainLayout.tsx
+++ b/src/components/home/MainLayout.tsx
@@ -4,6 +4,7 @@ import { CheckboxGroup, CalendarComponent } from '@/components';
 import { TOGGLE_BUTTON_TEXT } from '@/types/main';
 import { useMainViewportWidth } from '@/hooks/useMainViewportWidth';
 import { useAppSelector } from '@/hooks/useRedux';
+import { SalaryManage } from './SalaryManage';
 
 export function MainLayout() {
 	const year = useAppSelector((state) => state.schedule.year);
@@ -61,6 +62,7 @@ export function MainLayout() {
 
 				<S.PayrollContainer>
 					<S.PayrollTitle>급여 명세서</S.PayrollTitle>
+					<SalaryManage />
 				</S.PayrollContainer>
 			</S.RightSection>
 		</S.MainContainer>

--- a/src/components/home/SalaryManage.tsx
+++ b/src/components/home/SalaryManage.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import * as S from './MainLayout.styles';
+import { createClient } from '@supabase/supabase-js';
+import { useAppSelector } from '@/hooks/useRedux';
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+type EmployeeSalary = {
+	user_name: string;
+	total_salary: number;
+	payment_month: string;
+};
+
+export function SalaryManage() {
+	const year = useAppSelector((state) => state.schedule.year);
+	const month = useAppSelector((state) => state.schedule.month);
+
+	const [salaryList, setSalaryList] = useState<EmployeeSalary[]>();
+
+	useEffect(() => {
+		const fetchEmployeeSalaryData = async () => {
+			const { data, error } = await supabase
+				.from('attendance')
+				.select(
+					`
+					user_name,
+					total_salary,
+					payment_month
+				`,
+				)
+				.like('payment_month', `${year}-${String(month).padStart(2, '0')}%`);
+			if (error) {
+				console.error('Error fetching employeeSalary data:', error);
+			} else {
+				setSalaryList(data);
+			}
+		};
+
+		fetchEmployeeSalaryData();
+	}, [year, month]);
+
+	const goToSalaryManagePage = () => {
+		window.location.href = '/salary-management';
+	};
+
+	return (
+		<S.SalaryManageList>
+			{salaryList &&
+				salaryList.map((data) => (
+					<S.SalaryManageContent key={data.payment_month} onClick={goToSalaryManagePage}>
+						<p>{data.user_name}</p>
+						<p>{data.total_salary.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')} 원</p>
+					</S.SalaryManageContent>
+				))}
+		</S.SalaryManageList>
+	);
+}

--- a/src/pages/salary-management/SalaryManagement.tsx
+++ b/src/pages/salary-management/SalaryManagement.tsx
@@ -7,6 +7,7 @@ import Pagination from '@/components/pagination/pagination';
 import SalarySelect from '@/components/salaryselect/SalarySelect';
 import { createClient } from '@supabase/supabase-js';
 import { TMessage } from '@/types/modal';
+import { useAppSelector } from '@/hooks/useRedux';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -231,8 +232,17 @@ export function SalaryManagement() {
 
 	const headerItems: string[] = ['신청인', '급여월', '급여지급일', '지급예정금액', '상태'];
 	const [attendanceRequestData, setAttendanceRequestData] = useState<ManageRowItem[]>([]);
-	const [selectedYear, setSelectedYear] = useState<string>('2024');
-	const [selectedMonth, setSelectedMonth] = useState<string>('01');
+
+	const year = useAppSelector((state) => state.schedule.year);
+	const month = useAppSelector((state) => state.schedule.month);
+	const now = new Date();
+
+	const [selectedYear, setSelectedYear] = useState<string>(
+		year.toString() || now.getFullYear().toString(),
+	);
+	const [selectedMonth, setSelectedMonth] = useState<string>(
+		month.toString() || now.getMonth().toString().padStart(2, '0'),
+	);
 
 	const handleSelectChange = (event) => {
 		setFormData({


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

메인페이지 급여명세서 칸에 직원 이름과 급여의 내역 조회 및 salary-management 페이지로 연결

## 📋 작업 내용

 - 메인페이지 급여명세서 칸에 직원 이름과 급여의 내역 조회
 - 해당란 클릭시 salary-management 페이지로 연결

## 🔧 변경 사항

- 직원명-급여 리스트 컴포넌트 생성
- 요소 클릭시 해당 연,월의 salary-management 페이지로 이동
- salary-management 페이지에서 디폴트 값을 현재 연,월로 수정


## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/2dcfa6e8-8de9-4e3f-a7dd-ec9edf30c870)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
