### PR TITLE
[🔧 Fix] 메인페이지의 급여명세서를 통해 급여정정신청내역 페이지 진입시 select 값이 제대로 안 바뀌는 부분 수정

### DIFF
--- a/src/pages/salary-management/SalaryManagement.tsx
+++ b/src/pages/salary-management/SalaryManagement.tsx
@@ -131,7 +131,7 @@ export function SalaryManagement() {
 
 		try {
 			if (status === '승인') {
-				// attendance의 total_salary 변경
+				// attendance의 overtime_pay 변경
 				const { error: attendanceError } = await supabase
 					.from('attendance')
 					.update({
@@ -241,7 +241,7 @@ export function SalaryManagement() {
 		year.toString() || now.getFullYear().toString(),
 	);
 	const [selectedMonth, setSelectedMonth] = useState<string>(
-		month.toString() || now.getMonth().toString().padStart(2, '0'),
+		month.toString().padStart(2, '0') || now.getMonth().toString().padStart(2, '0'),
 	);
 
 	const handleSelectChange = (event) => {
@@ -314,13 +314,15 @@ export function SalaryManagement() {
 					)
 				`,
 				)
-				.like('attendance.payment_month', `${selectedYear}-${selectedMonth}%`)
+				.like(
+					'attendance.payment_month',
+					`${selectedYear}-${String(selectedMonth).padStart(2, '0')}%`,
+				)
 				.order('created_at', { ascending: false })
 				.range(startIndex, endIndex - 1);
 			if (error) {
 				console.error('Error fetching data:', error);
 			} else {
-				console.log(data);
 				const reorderedData: ManageRowItem[] = data.map((item: RequestData) => {
 					const attendance = Array.isArray(item.attendance) ? item.attendance[0] : item.attendance;
 					return {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

메인페이지의 급여명세서를 통해 급여정정신청내역 페이지 진입시 select 값이 제대로 안 바뀌는 부분 수정

## 📋 작업 내용

메인페이지의 급여명세서를 통해 급여정정신청내역 페이지 진입시 select 값이 제대로 안 바뀌는 부분 수정

## 🔧 변경 사항

state 값으로 있는 selectedMonth에 대하여 padStart로 월 형식 맞춤


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
