### PR TITLE
[🔧 Fix] 스케줄 반복 일정 계산 로직 개선, 수정 로직 개선 

### DIFF
--- a/src/components/schedule-management/schedule-card/admin-schedule-card/AdminScheduleCard.tsx
+++ b/src/components/schedule-management/schedule-card/admin-schedule-card/AdminScheduleCard.tsx
@@ -7,7 +7,7 @@ import {
 	setIsScheduleEditModalOpen,
 	setIsScheduleDeleteModalOpen,
 } from '@/redux/actions/modalActions';
-import { isSameDay, formatTime } from '@/utils/dateFormatter';
+import { isSameDate, formatTime } from '@/utils/dateFormatter';
 import filteredRepeatSchedules from '@/utils/filteredRepeatSchedules';
 
 const AdminScheduleCard = ({ schedule }: TAdminScheduleCardProps) => {
@@ -40,7 +40,7 @@ const AdminScheduleCard = ({ schedule }: TAdminScheduleCardProps) => {
 	// 전 날과 이어지는 스케줄인지 체크
 	const compareDate = new Date(selectedDate);
 	const startDate = new Date(schedule.start_date_time);
-	const isYesterdaySchedule = !isSameDay(compareDate, startDate);
+	const isYesterdaySchedule = !isSameDate(compareDate, startDate);
 
 	const hasDescription = !!schedule.description;
 

--- a/src/components/schedule-management/schedule-card/user-schedule-card/UserScheduleCard.tsx
+++ b/src/components/schedule-management/schedule-card/user-schedule-card/UserScheduleCard.tsx
@@ -17,7 +17,7 @@ export const UserScheduleCard = ({ schedule, shouldShowTime }: TUserScheduleCard
 	const user = useAppSelector((state) => state.user.user);
 	const userId = user?.id;
 
-	const { handleDeleteSchedule } = useScheduleManage(userId ?? null, schedules);
+	const { handleDeleteSchedule } = useScheduleManage(userId ?? '', schedules);
 
 	// 넘어가는 날짜 원 처리용
 	const compareDate = new Date(selectedDate);

--- a/src/components/schedule-management/schedule-card/user-schedule-card/UserScheduleCard.tsx
+++ b/src/components/schedule-management/schedule-card/user-schedule-card/UserScheduleCard.tsx
@@ -7,7 +7,7 @@ import {
 	setIsScheduleEditModalOpen,
 	setIsScheduleDeleteModalOpen,
 } from '@/redux/actions/modalActions';
-import { isSameDay, formatTime } from '@/utils/dateFormatter';
+import { isSameDate, formatTime } from '@/utils/dateFormatter';
 import filteredRepeatSchedules from '@/utils/filteredRepeatSchedules';
 
 export const UserScheduleCard = ({ schedule, shouldShowTime }: TUserScheduleCardProps) => {
@@ -24,8 +24,8 @@ export const UserScheduleCard = ({ schedule, shouldShowTime }: TUserScheduleCard
 	const startDate = new Date(schedule.start_date_time);
 	const endDate = new Date(schedule.end_date_time);
 
-	const showStartTime = isSameDay(compareDate, startDate);
-	const showEndTime = isSameDay(compareDate, endDate);
+	const showStartTime = isSameDate(compareDate, startDate);
+	const showEndTime = isSameDate(compareDate, endDate);
 
 	const startTime = formatTime(startDate);
 	const endTime = formatTime(endDate);

--- a/src/components/schedule-management/schedule-modal/ScheduleModal.tsx
+++ b/src/components/schedule-management/schedule-modal/ScheduleModal.tsx
@@ -188,7 +188,7 @@ export const ScheduleModal = ({ type, mode }: TScheduleModalProps) => {
 				time: data.time,
 				end_date_time: new Date(calculateEndDateTime(data.start_date_time, data.time)),
 				schedule_shift_type: calculateScheduleShiftType(data.start_date_time),
-				repeat: (data.repeat as TScheduleRepeatCycle) || undefined,
+				repeat: (data.repeat as TScheduleRepeatCycle) || null,
 				repeat_end_date: data.repeat_end_date ? new Date(data.repeat_end_date) : undefined,
 				created_at: new Date(),
 				description: (data.description as string) || undefined,

--- a/src/hooks/useScheduleManage.ts
+++ b/src/hooks/useScheduleManage.ts
@@ -8,6 +8,7 @@ import {
 } from '@/redux/actions/scheduleActions';
 import generateRepeatingSchedules from '@/utils/generateRepeatingSchedules';
 import filteredRepeatSchedules from '@/utils/filteredRepeatSchedules';
+import { isSameDate, isSameDateTime } from '@/utils/dateFormatter';
 
 export default function useScheduleManage(userId: string | null, schedules: TSchedule[]) {
 	const dispatch = useAppDispatch();
@@ -32,46 +33,56 @@ export default function useScheduleManage(userId: string | null, schedules: TSch
 		if (!prevSchedule) throw new Error('이전 스케줄 정보 없음');
 
 		const isRepeatChanged = prevSchedule.repeat !== newSchedule.repeat;
-
 		const isRepeatEndDateChanged =
 			prevSchedule.repeat_end_date &&
 			newSchedule.repeat_end_date &&
-			new Date(prevSchedule.repeat_end_date).getTime() !==
-				new Date(newSchedule.repeat_end_date).getTime();
+			!isSameDate(new Date(prevSchedule.repeat_end_date), new Date(newSchedule.repeat_end_date));
+		const isStartDateChanged = !isSameDateTime(
+			new Date(prevSchedule.start_date_time),
+			new Date(newSchedule.start_date_time),
+		);
 
 		try {
-			if (editAll || isRepeatChanged || isRepeatEndDateChanged) {
-				// - 전체 수정
-				// - 또는 단일 수정시 repeat, repeat_end_date이 수정됐으면
+			if (editAll || isRepeatChanged || isRepeatEndDateChanged || isStartDateChanged) {
+				// - 전체 수정 또는 단일 수정시에도 repeat, repeat_end_date이 변경됐으면
+
+				// 기존 반복 스케줄 계산
+				const repeatSchedules = filteredRepeatSchedules(prevSchedule, schedules);
+
 				// 기존 반복 스케줄 전체 삭제
-				const scheduleIds = filteredRepeatSchedules(prevSchedule, schedules).map(
-					(s) => s.schedule_id,
-				);
+				const scheduleIds = repeatSchedules.map((s) => s.schedule_id);
 
 				console.log('수정 전 삭제할 스케줄:', {
 					editAll,
 					isRepeatChanged,
 					isRepeatEndDateChanged,
+					isStartDateChanged,
 					scheduleIds,
 				});
 
-				// Supabase 삭제, 추가
+				// Supabase 삭제
 				const deleteResult = await dispatch(removeScheduleFromSupabase(userId, scheduleIds));
-
 				if (!deleteResult.success) throw new Error('수정 전 삭제 실패');
 
+				// start_date_time이 바뀌지 않았으면 기존 반복 스케줄의 첫번째 요소로 반복 스케줄 생성해야함
+				const baseStartDateTime = isStartDateChanged
+					? newSchedule.start_date_time // 새 start_date_time 반영
+					: repeatSchedules[0].start_date_time; // 기존 반복 스케줄의 첫번째 요소 사용
+
+				// 새 반복 스케줄 생성
 				const updatedSchedules = generateRepeatingSchedules({
 					...newSchedule,
+					start_date_time: baseStartDateTime,
 					schedule_id: uuidv4(), // 첫번째 스케줄에 새로운 ID 생성해줌
 				});
 
+				// Supabase 추가
 				const addResult = await dispatch(addScheduleToSupabase(userId, updatedSchedules));
-
 				if (!addResult.success) throw new Error('전체 수정 중 추가 실패');
 			} else {
 				// 단일 스케줄 수정
-				const editResult = await dispatch(editScheduleToSupabase([newSchedule]));
 
+				const editResult = await dispatch(editScheduleToSupabase([newSchedule]));
 				if (!editResult.success) throw new Error('단일 스케줄 수정 실패');
 			}
 		} catch (error) {
@@ -84,12 +95,44 @@ export default function useScheduleManage(userId: string | null, schedules: TSch
 		try {
 			if (!userId) throw new Error('userId가 없음');
 
+			const repeatSchedules = filteredRepeatSchedules(schedule, schedules);
+
 			const scheduleIds = deleteAll
-				? filteredRepeatSchedules(schedule, schedules).map((s) => s.schedule_id)
+				? repeatSchedules.map((s) => s.schedule_id)
 				: [schedule.schedule_id];
 
 			const deleteResult = await dispatch(removeScheduleFromSupabase(userId, scheduleIds));
 			if (!deleteResult.success) throw new Error('삭제 실패');
+
+			// 반복 스케줄 중 삭제가 일어나면 시작, 반복 종료 날짜 조정 필요
+			const targetIndex = repeatSchedules.findIndex((s) => s.schedule_id === schedule.schedule_id);
+
+			if (!deleteAll && repeatSchedules.length > 1 && targetIndex !== 0) {
+				// 이전 스케줄들 종료 날짜 수정
+				const prevSchedules = repeatSchedules.slice(0, targetIndex).map((prev) => {
+					const prevEndDate = new Date(schedule.start_date_time);
+					prevEndDate.setUTCDate(prevEndDate.getUTCDate() - 1); // 삭제 스케줄 직전 날짜 설정
+					return {
+						...prev,
+						repeat_end_date: prevEndDate,
+					};
+				});
+
+				// 이후 스케줄들 시작 날짜 수정
+				const nextSchedules = repeatSchedules.slice(targetIndex + 1).map((next, i) => {
+					const nextStartDate = new Date(schedule.start_date_time);
+					nextStartDate.setUTCDate(nextStartDate.getUTCDate() + (i + 1)); // 순서에 따라 날짜 증가
+					return {
+						...next,
+						start_date_time: nextStartDate,
+					};
+				});
+
+				const updatedSchedules = [...prevSchedules, ...nextSchedules];
+
+				// Supabase 수정
+				await dispatch(editScheduleToSupabase(updatedSchedules));
+			}
 		} catch (error) {
 			console.error('스케줄 삭제 실패:', error);
 			throw error;

--- a/src/hooks/useScheduleManage.ts
+++ b/src/hooks/useScheduleManage.ts
@@ -163,8 +163,12 @@ export default function useScheduleManage(userId: string, schedules: TSchedule[]
 			await deleteSchedules(scheduleIds);
 
 			// 반복 스케줄 중 삭제가 일어나면 전 반복 스케줄의 반복 종료 날짜 조정 필요
-			const targetIndex = repeatSchedules.findIndex((s) => s.schedule_id === schedule.schedule_id);
-			await adjustPreviousSchedules(repeatSchedules, targetIndex, schedule.start_date_time);
+			if (!deleteAll && repeatSchedules.length > 1) {
+				const targetIndex = repeatSchedules.findIndex(
+					(s) => s.schedule_id === schedule.schedule_id,
+				);
+				await adjustPreviousSchedules(repeatSchedules, targetIndex, schedule.start_date_time);
+			}
 		} catch (error) {
 			console.error('스케줄 삭제 실패:', error);
 			throw error;

--- a/src/pages/schedule-management/ScheduleManagement.tsx
+++ b/src/pages/schedule-management/ScheduleManagement.tsx
@@ -24,7 +24,7 @@ export function ScheduleManagement() {
 	);
 	const isAdmin = useIsAdmin();
 
-	const { handleDeleteSchedule } = useScheduleManage(selectedSchedule?.user_id ?? null, schedules);
+	const { handleDeleteSchedule } = useScheduleManage(selectedSchedule?.user_id ?? '', schedules);
 
 	const handleConfirmDelete = async (deleteAll: boolean) => {
 		try {

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -47,8 +47,13 @@ export const isSameTime = (d1: Date, d2: Date): boolean => {
 };
 
 // KST 기준으로 날짜 비교
-export const isSameDay = (d1: Date, d2: Date): boolean => {
+export const isSameDate = (d1: Date, d2: Date): boolean => {
 	return formatDate(d1) === formatDate(d2);
+};
+
+// KST 기준으로 날짜, 시간 비교
+export const isSameDateTime = (d1: Date, d2: Date): boolean => {
+	return formatDateTime(d1) === formatDateTime(d2);
 };
 
 // 분을 '00'으로 고정

--- a/src/utils/filterSchedules.ts
+++ b/src/utils/filterSchedules.ts
@@ -1,5 +1,5 @@
 import { TSchedule } from '@/types/schedule';
-import { isSameDay } from './dateFormatter';
+import { isSameDate } from './dateFormatter';
 
 // 데이터 필터링
 // 시작, 끝나는 시간 체크, 시작시간으로 정렬
@@ -12,8 +12,8 @@ export function filterSchedulesByDateAndSort(
 			const scheduleDate = new Date(schedule.start_date_time);
 			const compareDate = new Date(selectedDate);
 			return (
-				isSameDay(scheduleDate, compareDate) ||
-				(schedule.end_date_time ? isSameDay(new Date(schedule.end_date_time), compareDate) : true)
+				isSameDate(scheduleDate, compareDate) ||
+				(schedule.end_date_time ? isSameDate(new Date(schedule.end_date_time), compareDate) : true)
 			);
 		})
 		.sort((a, b) => {

--- a/src/utils/filteredRepeatSchedules.ts
+++ b/src/utils/filteredRepeatSchedules.ts
@@ -1,86 +1,27 @@
-// import { TSchedule } from '@/types/schedule';
-
-// // 반복 조건 충족 여부
-// function isRepeatDate(schedule: TSchedule, target: TSchedule): boolean {
-// 	const scheduleDate = new Date(schedule.start_date_time);
-// 	const targetDate = new Date(target.start_date_time);
-
-// 	switch (schedule.repeat) {
-// 		case 'everyDay':
-// 			return true;
-// 		case 'everyWeek':
-// 			return scheduleDate.getDay() === targetDate.getDay();
-// 		case 'everyMonth':
-// 			return scheduleDate.getDate() === targetDate.getDate();
-// 		default:
-// 			return false;
-// 	}
-// }
-
-//  // 반복 범위 내 존재 여부
-// function isWithinRepeatRange(schedule: TSchedule, target: TSchedule): boolean {
-// 	if (!schedule.repeat || !target.repeat || schedule.repeat !== target.repeat) {
-// 		return false;
-// 	}
-
-// 	const scheduleStartDate = new Date(schedule.start_date_time);
-// 	const scheduleEndDate = schedule.repeat_end_date
-// 		? new Date(schedule.repeat_end_date)
-// 		: null;
-
-// 	const targetStartDate = new Date(target.start_date_time);
-// 	const targetEndDate = target.repeat_end_date
-// 		? new Date(target.repeat_end_date)
-// 		: null;
-
-// 	if (scheduleEndDate) {
-// 		scheduleStartDate.getUTCHours() === 15 ? scheduleEndDate : scheduleEndDate.setUTCHours(23, 59, 59, 999);
-// 	}
-
-// 	if (targetEndDate) {
-// 		targetStartDate.getUTCHours() === 15 ? targetEndDate : targetEndDate.setUTCHours(23, 59, 59, 999);
-// 	}
-
-// 	// 날짜 겹침 확인
-// 	if (scheduleEndDate && targetEndDate) {
-// 		return (
-// 			targetStartDate <= scheduleEndDate && scheduleStartDate <= targetEndDate
-// 		);
-// 	}
-
-// 	return true; // 종료 날짜가 없으면 계속 반복
-// }
-
-// export default function filteredRepeatSchedules(
-// 	schedule: TSchedule,
-// 	schedules: TSchedule[]
-// ) {
-//   console.log('스케줄 비교 시작:', { schedule, schedules });
-// 	return schedules.filter((s) => {
-// 		const match =
-// 			s.user_id === schedule.user_id
-// 			s.category === schedule.category &&
-// 			s.time === schedule.time &&
-// 			isRepeatDate(schedule, s) &&
-// 			isWithinRepeatRange(schedule, s) &&
-// 			s.schedule_shift_type === schedule.schedule_shift_type
-// 		console.log('비교 결과:', { schedule: s, match });
-// 		return match;
-// 	});
-// }
-
 import { TSchedule } from '@/types/schedule';
+import { isSameDate } from './dateFormatter';
 
 export default function filteredRepeatSchedules(schedule: TSchedule, schedules: TSchedule[]) {
-	// console.log('스케줄 비교 시작:', { schedule, schedules });
+	console.log('스케줄 비교 시작:', { schedule, schedules });
 	return schedules.filter((s) => {
-		const match =
-			s.category === schedule.category &&
-			s.time === schedule.time &&
-			s.repeat === schedule.repeat &&
-			s.schedule_shift_type === schedule.schedule_shift_type;
+		const isUserIdSame = s.user_id === schedule.user_id;
+		const isCategorySame = s.category === schedule.category;
+		const isTimeSame = s.time === schedule.time;
+		const isRepeatSame = s.repeat === schedule.repeat;
+		const isRepeatEndDateSame =
+			s.repeat_end_date &&
+			schedule.repeat_end_date &&
+			isSameDate(new Date(s.repeat_end_date), new Date(schedule.repeat_end_date));
+		const isShiftTypeSame = s.schedule_shift_type === schedule.schedule_shift_type;
 
-		// console.log('비교 결과:', { schedule: s, match });
+		const match =
+			isUserIdSame &&
+			isCategorySame &&
+			isTimeSame &&
+			isRepeatSame &&
+			isRepeatEndDateSame &&
+			isShiftTypeSame;
+		console.log('비교 결과:', { schedule: s, match });
 		return match;
 	});
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### ✅ scheduleActions의 editScheduleToSupabase에서 병렬처리하게 함

### ✅ 수정 로직 수정

1. 전체 수정 (editAll === true)
기존 반복 스케줄 전체 삭제
- start_date_time이 변경된 경우:
       newSchedule 기준으로 새 반복 스케줄 생성
- start_date_time이 변경되지 않은 경우:
       기존 반복 스케줄의 첫 번째 요소를 기준으로 새 반복 스케줄 생성

2. 단일 수정 (editAll === false)
- 반복 설정이 있는 경우 (repeatSchedules.length > 1):
    - isRepeatChanged, isRepeatEndDateChanged, isStartDateChanged 중 하나라도 변경되지 않은 경우
        - 반복 설정 제거 (repeat,repeat_end_date를 undefined로 설정)
        - 해당 스케줄만 수정
        - **이전 스케줄들의 repeat_end_date**를 수정된 스케줄의 **start_date_time - 1**로 조정
    - isRepeatChanged, isRepeatEndDateChanged, isStartDateChanged 중 하나라도 변경된 경우
        - 해당 스케줄 삭제
        - 이전 스케줄들의 repeat_end_date 조정
        - newSchedule 기준으로 새로운 반복 스케줄 생성 및 추가
- 반복 설정이 없는 경우 (repeatSchedules.length === 1)
    - isRepeatChanged or isRepeatEndDateChanged가 변경된 경우
        해당 스케줄을 삭제하고 새로운 반복 스케줄을 추가
    - 정말 반복 설정이 없으면 
        단일 스케줄만 수정

### ✅ 삭제 로직 수정
- deleteAll인 경우
모든 반복 스케줄을 삭제
- 단일 삭제인 경우
해당 스케줄만 삭제
    - 반복 스케줄인 경우
        해당 스케줄만 삭제하고 이전 스케줄들의 종료 날짜를 조정

## 📋 작업 내용

## 🔧 변경 사항

- [ ] 수정 로직 수정
- [ ] 삭제 로직 수정


## 📸 스크린샷 (선택 사항)


## 📄 기타

