### PR TITLE
[🔄 Refactor] 사용자 급여 내역 페이지 select 최신 월로 설정, 급여에 `,` 구분자 추가

### DIFF
--- a/src/components/PaginatedTable/DetailModal/detailModal.style.ts
+++ b/src/components/PaginatedTable/DetailModal/detailModal.style.ts
@@ -6,6 +6,7 @@ export const PayrollContainer = styled.div`
 	padding: 20px;
 	border-radius: 8px;
 	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	word-break: keep-all;
 `;
 
 export const PayrollHeader = styled.header`

--- a/src/components/PaginatedTable/DetailModal/detailModal.tsx
+++ b/src/components/PaginatedTable/DetailModal/detailModal.tsx
@@ -11,6 +11,8 @@ import {
 	SummaryValue,
 	SummaryLabel,
 } from './detailModal.style';
+import { salaryFormatter } from '@/utils/salaryFormatter';
+
 export default function DetailModal({ data }) {
 	return (
 		<PayrollContainer>
@@ -31,19 +33,21 @@ export default function DetailModal({ data }) {
 					<tbody>
 						<tr>
 							<TableData>기본 급여</TableData>
-							<TableData>{data.지급총액} 원</TableData>
+							<TableData>{salaryFormatter(data.지급총액)} 원</TableData>
 						</tr>
 						<tr>
 							<TableData>세금 공제</TableData>
-							<TableData>-{data.세금공제} 원</TableData>
+							<TableData>-{salaryFormatter(data.세금공제)} 원</TableData>
 						</tr>
 						<tr>
 							<TableData>보험 공제</TableData>
-							<TableData>-{data.보험공제} 원</TableData>
+							<TableData>-{salaryFormatter(data.보험공제)} 원</TableData>
 						</tr>
 						<tr>
 							<TableData>정정 반영 금액</TableData>
-							<TableData>{data.수정금액 && `+${data.수정금액}`} 원</TableData>
+							<TableData>
+								{salaryFormatter(data.수정금액 ? data.수정금액 && `+${data.수정금액}` : '0')} 원
+							</TableData>
 						</tr>
 					</tbody>
 				</PayrollTable>
@@ -52,11 +56,11 @@ export default function DetailModal({ data }) {
 				<h2>합계</h2>
 				<SummaryItem>
 					<SummaryLabel>지급총액</SummaryLabel>
-					<SummaryValue>{data.지급총액} 원</SummaryValue>
+					<SummaryValue>{salaryFormatter(data.지급총액)} 원</SummaryValue>
 				</SummaryItem>
 				<SummaryItem>
 					<SummaryLabel>실수령액</SummaryLabel>
-					<SummaryValue>{data.실지급액} 원</SummaryValue>
+					<SummaryValue>{salaryFormatter(data.실지급액)} 원</SummaryValue>
 				</SummaryItem>
 			</PayrollSummary>
 		</PayrollContainer>

--- a/src/components/PaginatedTable/EditModal/editModal.tsx
+++ b/src/components/PaginatedTable/EditModal/editModal.tsx
@@ -3,6 +3,7 @@ import { useState, useRef } from 'react';
 import { Button } from '@/components';
 import { createClient } from '@supabase/supabase-js';
 import { ConfirmModal } from '@/components/modal/Modal';
+import { salaryFormatter } from '@/utils/salaryFormatter';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -101,7 +102,7 @@ export default function EditModal({ data }) {
 					<p>급여지급일: {data['급여지급일']}</p>
 				</Info>
 				<Info>
-					<p>기존금액: {data['실지급액']}</p>
+					<p>기존금액: {salaryFormatter(data['실지급액'])}</p>
 					<p>
 						미반영 정정신청 금액:{' '}
 						<input

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -37,18 +37,36 @@ export default function PaginatedTable() {
 	};
 
 	//데이터 상태
-	const [selectedYear, setSelectedYear] = useState<string>('2024');
-	const [selectedMonth, setSelectedMonth] = useState<string>('01');
+	const [selectedYear, setSelectedYear] = useState<string>('');
+	const [selectedMonth, setSelectedMonth] = useState<string>('');
 	const [filteredItems, setFilteredItems] = useState<RowItem[]>([]);
 	const [diffInDays, setDiffInDays] = useState<number | null>(null);
 
 	//supabase 조회 커스텀훅
 	const { rowItems: rowItems } = useSalaryUserData();
 
+	// rowItems에서 가장 최신 급여내역 연도, 월 추출
+	useEffect(() => {
+		if (rowItems.length > 0) {
+			const sortedItems = [...rowItems].sort((a, b) => {
+				const dateA = new Date(a.급여월);
+				const dateB = new Date(b.급여월);
+				return dateB.getTime() - dateA.getTime();
+			});
+
+			const latestItem = sortedItems[0];
+			const latestYear = latestItem.급여월.substring(0, 4);
+			const latestMonth = latestItem.급여월.substring(5, 7);
+
+			setSelectedYear(latestYear);
+			setSelectedMonth(latestMonth);
+		}
+	}, [rowItems]);
+
 	useEffect(() => {
 		if (filteredItems.length > 0) {
 			const salaryDate = filteredItems[0].급여지급일;
-			console.log('급여지급일:', salaryDate);
+			// console.log('급여지급일:', salaryDate);
 
 			const supabaseDate = dayjs(salaryDate, 'YYYY-MM-DD');
 			if (supabaseDate.isValid()) {
@@ -77,7 +95,7 @@ export default function PaginatedTable() {
 	const startIndex = (currentPage - 1) * itemsPerPage;
 	const endIndex = startIndex + itemsPerPage;
 	const paginatedData: RowItem[] = filteredItems.slice(startIndex, endIndex);
-	console.log(paginatedData);
+	// console.log(paginatedData);
 
 	const totalPages = Math.ceil(filteredItems.length / itemsPerPage);
 

--- a/src/components/footer/Footer.style.ts
+++ b/src/components/footer/Footer.style.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const FooterContainer = styled.footer`
 	padding: var(--space-small);
 	border-top: 1px solid var(--color-light-gray);
+	background-color: var(--color-white);
 	font-size: var(--font-medium);
 	text-align: right;
 `;

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -1,6 +1,7 @@
 import { ManageRowItem } from '@/pages/salary-management/SalaryManagement';
 import { TableContainer, Lists, InnerUnorderLists, InnerLists } from './Table.styled';
 import { Button } from '@/components';
+import { salaryFormatter } from '@/utils/salaryFormatter';
 
 type TableProps = {
 	data: RowItem[] | ManageRowItem[];
@@ -47,7 +48,12 @@ export default function Table({
 					<Lists key={idx}>
 						<InnerUnorderLists>
 							{headerItems.slice(0, 4).map((header, idx1) => (
-								<InnerLists key={idx1}>{row[header as keyof RowItem] ?? ''}</InnerLists>
+								<InnerLists key={idx1}>
+									{/* 지급총액과 실지급액에만 포맷팅 적용 */}
+									{header === '지급총액' || header === '실지급액'
+										? salaryFormatter(row[header as keyof RowItem] as string)
+										: (row[header as keyof RowItem] ?? '')}
+								</InnerLists>
 							))}
 							<InnerLists>
 								<Button

--- a/src/hooks/useSalaryUserData.ts
+++ b/src/hooks/useSalaryUserData.ts
@@ -9,7 +9,7 @@ export default function useSalaryUserData() {
 
 	useEffect(() => {
 		const fetchAttendanceData = async () => {
-			console.log('급여 데이터 fetch 시작');
+			// console.log('급여 데이터 fetch 시작');
 
 			const { data, error } = await supabase
 				.from('attendance')

--- a/src/utils/salaryFormatter.ts
+++ b/src/utils/salaryFormatter.ts
@@ -1,0 +1,4 @@
+export const salaryFormatter = (salary: string) => {
+	if (!salary) return '';
+	return salary.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

사용자 급여 내역 페이지에서 셀렉트 초기 설정을 최신 급여 내역의 년, 월로 설정
급여에 , 구분자 추가

## 📋 작업 내용

```
// src/utils/salaryFormatter.ts
// 금액에 구분자 추가하는 함수
export const salaryFormatter = (salary: string) => {
	if (!salary) return '';
	return salary.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
};
```

```
// 사용
import { salaryFormatter } from '@/utils/salaryFormatter';

<TableData>-{salaryFormatter(data.세금공제)} 원</TableData>
```

## 🔧 변경 사항

위 내용 참고해주세요.


## 📸 스크린샷 (선택 사항)

<img width="1293" alt="image" src="https://github.com/user-attachments/assets/0bf29363-26bc-46e6-9950-d33aced07688" />

## 📄 기타

close #164 
